### PR TITLE
Fix Firefly configs

### DIFF
--- a/GameData/DebdebSystem/Firefly/Donk.cfg
+++ b/GameData/DebdebSystem/Firefly/Donk.cfg
@@ -1,6 +1,8 @@
 ATMOFX_BODY
 {
-	name = Duna
+	name = Donk
+	config_version = 5
+
 	strength_multiplier = 0.5
 	
 	length_multiplier = 1

--- a/GameData/DebdebSystem/Firefly/Gurdamma.cfg
+++ b/GameData/DebdebSystem/Firefly/Gurdamma.cfg
@@ -1,6 +1,8 @@
 ATMOFX_BODY
 {
 	name = Gurdamma
+	config_version = 5
+
 	strength_multiplier = 1
 	
 	length_multiplier = 1

--- a/GameData/DebdebSystem/Firefly/Merbel.cfg
+++ b/GameData/DebdebSystem/Firefly/Merbel.cfg
@@ -1,6 +1,8 @@
 ATMOFX_BODY
 {
 	name = Merbel
+	config_version = 5
+
 	strength_multiplier = 1
 	length_multiplier = 1
 	opacity_multiplier = 1

--- a/GameData/DebdebSystem/Firefly/Ovin.cfg
+++ b/GameData/DebdebSystem/Firefly/Ovin.cfg
@@ -1,6 +1,8 @@
 ATMOFX_BODY
 {
 	name = Ovin
+	config_version = 5
+
 	strength_multiplier = 0.5
 	length_multiplier = 1
 	opacity_multiplier = 1


### PR DESCRIPTION
Add version numbers to allow Firefly to properly load the configs. Also change the name of the Donk config from "Duna" to "Donk" since Firefly doesn't allow duplicate names.