### PR TITLE
Fix typos in ParallaxScaled.cfg

### DIFF
--- a/GameData/PromisedWorlds/_Systems/Debdeb/Parallax/ParallaxScaled/ParallaxScaled.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Parallax/ParallaxScaled/ParallaxScaled.cfg
@@ -15,7 +15,7 @@
                 _ColorMap = PromisedWorlds/_Systems/Debdeb/PluginData/Gurdamma_Color_Scaled.dds
                 _BumpMap = PromisedWorlds/_Systems/Debdeb/PluginData/Gurdamma_Normal.dds
                 _HeightMap = PromisedWorlds/_Systems/Debdeb/PluginData/Gurdamma_Height.dds
-		_AtmosphereRimMap = Parallax_StockPlanetTextures/Kerbin/PluginData/Kerbin_Atmo.dds
+				_AtmosphereRimMap = Parallax_StockPlanetTextures/Kerbin/PluginData/Kerbin_Atmo.dds
                 _PlanetBumpScale = 1
 
                 _OceanSpecularPower = 0.5
@@ -296,7 +296,7 @@
                 _HeightMap = PromisedWorlds/_Systems/Debdeb/PluginData/Bis_Height.dds
                 _PlanetBumpScale = 1.0
                 
-				_AtmosphereRimMap = Parallax_StockPlanetTextures/Duna/PluginData/Kerbin_Atmo.dds
+				_AtmosphereRimMap = Parallax_StockPlanetTextures/Kerbin/PluginData/Kerbin_Atmo.dds
 				_AtmosphereThickness = 15
                 
                 Keywords


### PR DESCRIPTION
There are some typos which try to access Duna/PluginData/Kerbin_Atmo.dds, which does not exist. This was fixed to Kerbin.
Found in this issue: https://github.com/PromisedWorlds/PromisedWorlds/issues/92 